### PR TITLE
Add experiment with nested iterators using proper shifts instead of derefedNbShift

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+dist/
+dist-newstyle/

--- a/haskell-iterator-ir.cabal
+++ b/haskell-iterator-ir.cabal
@@ -38,4 +38,5 @@ test-suite haskell-iterator-ir-test
                        CartesianTests,
                        ToyConnectivity,
                        ToyConnectivityTests,
-                       ToyConnectivity2DTests
+                       ToyConnectivity2DTests,
+                       ToyConnectivityNestedTests

--- a/src/IteratorIr.hs
+++ b/src/IteratorIr.hs
@@ -58,7 +58,15 @@ lift2 g (It f a) (It f' a') = It (\x -> g (It f x) (It f' x)) a  -- TODO: a and 
 
 derefedNbShift :: (a -> [b]) -> Iterator a b t -> [t]
 derefedNbShift = iexperiment
+nbShift :: (b -> [c]) -> Iterator a c t -> Iterator a b [t]
 nbShift = lift . derefedNbShift
+
+-- This looks like a Traversal optic (see: Control.Lens.Traversal)
+-- neighborhood :: Traversal i j (Iterator i p t) (Iterator j p t)
+-- neighborhood :: Applicative f => (a -> f b) -> Iterator a c t -> f (Iterator b c t)
+neighborhood :: (a -> [b]) -> Iterator a c t -> [Iterator b c t]
+neighborhood a2b (It acc a) = fmap (It acc) (a2b a)
+
 
 itZip2 (It f a) (It f' a') = It (\x -> (f x, f' x)) a
 -- or equivalently: itZip2 = lift2 $ \x y -> (deref x, deref y)
@@ -66,4 +74,3 @@ itUnzip2 i = (ifmap fst i, ifmap snd i)
 
 reduce1 f i = foldl f i . deref
 reduce2 f i a b = foldl (\x (y, z) -> f x y z) i $ zip (deref a) (deref b)
-

--- a/src/IteratorIr.hs
+++ b/src/IteratorIr.hs
@@ -8,6 +8,7 @@ module IteratorIr (
     lift,
     lift2,
     derefedNbShift,
+    neighborhood,
     nbShift,
     reduce1,
     reduce2

--- a/src/IteratorIr.hs
+++ b/src/IteratorIr.hs
@@ -62,7 +62,7 @@ nbShift :: (b -> [c]) -> Iterator a c t -> Iterator a b [t]
 nbShift = lift . derefedNbShift
 
 -- This looks like a Traversal optic (see: Control.Lens.Traversal)
--- neighborhood :: Traversal i j (Iterator i p t) (Iterator j p t)
+-- neighborhood :: Traversal a b (Iterator a p t) (Iterator b p t)
 -- neighborhood :: Applicative f => (a -> f b) -> Iterator a c t -> f (Iterator b c t)
 neighborhood :: (a -> [b]) -> Iterator a c t -> [Iterator b c t]
 neighborhood a2b (It acc a) = fmap (It acc) (a2b a)

--- a/test/IteratorIrTest.hs
+++ b/test/IteratorIrTest.hs
@@ -7,8 +7,9 @@ import IteratorIr
 import CartesianTests
 import ToyConnectivityTests
 import ToyConnectivity2DTests
+import ToyConnectivityNestedTests
 
-tests = cartesianTests ++ toyConnectivityTests ++ toyConnectivity2DTests
+tests = cartesianTests ++ toyConnectivityTests ++ toyConnectivity2DTests ++ toyConnectivityNestedTests
 
 main :: IO()
 main = defaultMain tests

--- a/test/ToyConnectivity.hs
+++ b/test/ToyConnectivity.hs
@@ -13,7 +13,7 @@ module ToyConnectivity (
 
 newtype VertexIndex = Vertex { vIdx :: Int } deriving (Eq, Show)
 newtype EdgeIndex = Edge { eIdx :: Int } deriving (Eq, Show)
-newtype CellIndex = Cell { cIdx :: Int }  deriving (Eq, Show)
+newtype CellIndex = Cell { cIdx :: Int } deriving (Eq, Show)
 
 c2eList = [
         [0, 10, 3, 9],

--- a/test/ToyConnectivity.hs
+++ b/test/ToyConnectivity.hs
@@ -11,9 +11,9 @@ module ToyConnectivity (
     v2e
 ) where
 
-newtype VertexIndex = Vertex { vIdx :: Int } deriving Show
-newtype EdgeIndex = Edge { eIdx :: Int } deriving Show
-newtype CellIndex = Cell { cIdx :: Int } deriving Show
+newtype VertexIndex = Vertex { vIdx :: Int } deriving (Eq, Show)
+newtype EdgeIndex = Edge { eIdx :: Int } deriving (Eq, Show)
+newtype CellIndex = Cell { cIdx :: Int }  deriving (Eq, Show)
 
 c2eList = [
         [0, 10, 3, 9],

--- a/test/ToyConnectivityNestedTests.hs
+++ b/test/ToyConnectivityNestedTests.hs
@@ -31,6 +31,7 @@ eItOnE = It eIdx (Edge 0)
 toyConnectivityNestedTests = [
         testGroup "toyConnectivityNestedTests" [
             testCase "neighborhood" $ fmap deref (neighborhood e2v vItOnE) @?= [1, 2],
+            testCase "neighborhood as derefedNbShift" $ fmap deref (neighborhood e2v vItOnE) @?= derefedNbShift e2v vItOnE,
             testCase "lifted neighborhood" $ let liftedN = lift (neighborhood e2v) vItOnE
                                              in (ipos liftedN, fmap deref (deref liftedN)) @?= (Edge 1, [1, 2]),
             testCase "reduce lifted neighborhood" $ reduce1 (\accum it -> accum + deref it) 0 (lift (neighborhood e2v) vItOnE) @?= 3

--- a/test/ToyConnectivityNestedTests.hs
+++ b/test/ToyConnectivityNestedTests.hs
@@ -31,8 +31,8 @@ eItOnE = It eIdx (Edge 0)
 toyConnectivityNestedTests = [
         testGroup "toyConnectivityNestedTests" [
             testCase "neighborhood" $ fmap deref (neighborhood e2v vItOnE) @?= [1, 2],
-            testCase "lifted neighborhood" $ let liftedN = lift1 (neighborhood e2v) vItOnE
+            testCase "lifted neighborhood" $ let liftedN = lift (neighborhood e2v) vItOnE
                                              in (ipos liftedN, fmap deref (deref liftedN)) @?= (Edge 1, [1, 2]),
-            testCase "reduce lifted neighborhood" $ reduce1 (\accum it -> accum + deref it) 0 (lift1 (neighborhood e2v) vItOnE) @?= 3
+            testCase "reduce lifted neighborhood" $ reduce1 (\accum it -> accum + deref it) 0 (lift (neighborhood e2v) vItOnE) @?= 3
         ]
     ]

--- a/test/ToyConnectivityNestedTests.hs
+++ b/test/ToyConnectivityNestedTests.hs
@@ -1,0 +1,38 @@
+module ToyConnectivityNestedTests (
+    toyConnectivityNestedTests
+) where
+
+import Test.HUnit
+import Test.Framework
+import Test.Framework.Providers.HUnit
+
+import Control.Lens.Internal.Context
+
+import IteratorIr
+import ToyConnectivity
+
+stencil2 x y = deref x + deref y
+
+scalarProd = (sum .) . zipWith (*)
+
+
+edgesToVertices inp = [
+        deref $ shift (nb v2e 0) inp,
+        deref $ shift (nb v2e 1) inp,
+        deref $ shift (nb v2e 2) inp,
+        deref $ shift (nb v2e 3) inp
+    ]
+
+vItOnV = It vIdx (Vertex 0)
+eItOnV = It eIdx (Vertex 0)
+vItOnE = It vIdx (Edge 1)
+eItOnE = It eIdx (Edge 0)
+
+toyConnectivityNestedTests = [
+        testGroup "toyConnectivityNestedTests" [
+            testCase "neighborhood" $ fmap deref (neighborhood e2v vItOnE) @?= [1, 2],
+            testCase "lifted neighborhood" $ let lifted_n = lift1 (neighborhood e2v) vItOnE
+                                             in (ipos lifted_n, fmap deref (deref lifted_n)) @?= (Edge 1, [1, 2]),
+            testCase "reduce lifted neighborhood" $ reduce1 (\accum it -> accum + deref it) 0 (lift1 (neighborhood e2v) vItOnE) @?= 3
+        ]
+    ]

--- a/test/ToyConnectivityNestedTests.hs
+++ b/test/ToyConnectivityNestedTests.hs
@@ -31,8 +31,8 @@ eItOnE = It eIdx (Edge 0)
 toyConnectivityNestedTests = [
         testGroup "toyConnectivityNestedTests" [
             testCase "neighborhood" $ fmap deref (neighborhood e2v vItOnE) @?= [1, 2],
-            testCase "lifted neighborhood" $ let lifted_n = lift1 (neighborhood e2v) vItOnE
-                                             in (ipos lifted_n, fmap deref (deref lifted_n)) @?= (Edge 1, [1, 2]),
+            testCase "lifted neighborhood" $ let liftedN = lift1 (neighborhood e2v) vItOnE
+                                             in (ipos liftedN, fmap deref (deref liftedN)) @?= (Edge 1, [1, 2]),
             testCase "reduce lifted neighborhood" $ reduce1 (\accum it -> accum + deref it) 0 (lift1 (neighborhood e2v) vItOnE) @?= 3
         ]
     ]


### PR DESCRIPTION
Add `neighborhood` function to shift iterators to multiple indices using regular shifts.

This approach is basically the opposite of `derefedNbShift` and generates a collection of iterators whose position has been shifted, instead of a collection of values as happens with `derefedNbShift` , or a single iterator for a list of values as happens with `lift . derefedNbShift`.